### PR TITLE
fix: resolve recursion, NPEs, tier calculation bugs, and optimize block state checks

### DIFF
--- a/src/main/java/com/mo_guang/ctpp/api/CTPPMultiblockBuilder.java
+++ b/src/main/java/com/mo_guang/ctpp/api/CTPPMultiblockBuilder.java
@@ -86,7 +86,7 @@ public class CTPPMultiblockBuilder extends CTNHMultiblockMachineBuilder {
     }
 
     public CTPPMultiblockBuilder recoveryItems(Supplier<ItemLike[]> items) {
-        this.recoveryItems(items);
+        super.recoveryItems(items);
         return this;
     }
 

--- a/src/main/java/com/mo_guang/ctpp/client/toolbox/CTPPToolboxRadialScreen.java
+++ b/src/main/java/com/mo_guang/ctpp/client/toolbox/CTPPToolboxRadialScreen.java
@@ -154,7 +154,7 @@ public final class CTPPToolboxRadialScreen extends AbstractSimiScreen {
         }
         if (hovered == DEPOSIT) {
             GTNetwork.sendToServer(new CTPPToolboxActionPacket(CTPPToolboxActionPacket.Action.DEPOSIT,
-                    selectingSources ? null : currentSource().source(), -1, hotbarSlot));
+                    selectingSources || currentSource() == null ? null : currentSource().source(), -1, hotbarSlot));
             return;
         }
         CTPPToolboxSnapshot source = currentSource();

--- a/src/main/java/com/mo_guang/ctpp/common/kinetic/fan/acidwashing/AcidWashingProcessingType.java
+++ b/src/main/java/com/mo_guang/ctpp/common/kinetic/fan/acidwashing/AcidWashingProcessingType.java
@@ -120,6 +120,7 @@ public class AcidWashingProcessingType implements FanProcessingType {
                     SoundSource.NEUTRAL, 1.25f, 0.65f);
 
             Slime newslime = EntityType.SLIME.create(level);
+            if (newslime == null) return;
             CompoundTag serializeNBT = slime.saveWithoutId(new CompoundTag());
             serializeNBT.remove("UUID");
             serializeNBT.putInt("CTPPAcidwashing", 0);

--- a/src/main/java/com/mo_guang/ctpp/common/kinetic/fan/breathing/BreathingFanProcessingType.java
+++ b/src/main/java/com/mo_guang/ctpp/common/kinetic/fan/breathing/BreathingFanProcessingType.java
@@ -121,6 +121,7 @@ public class BreathingFanProcessingType implements FanProcessingType {
                     SoundSource.NEUTRAL, 1.25f, 0.65f);
 
             Endermite endermite = EntityType.ENDERMITE.create(level);
+            if (endermite == null) return;
             CompoundTag serializeNBT = silverfish.saveWithoutId(new CompoundTag());
             serializeNBT.remove("UUID");
 

--- a/src/main/java/com/mo_guang/ctpp/common/machine/multiblock/KineticMultiblockMachine.java
+++ b/src/main/java/com/mo_guang/ctpp/common/machine/multiblock/KineticMultiblockMachine.java
@@ -125,6 +125,7 @@ public abstract class KineticMultiblockMachine extends RecipeMultiblockMachine
     }
 
     public void checkTier() {
+        tier = 0;
         for (IMultiPart multiPart : getParts()) {
             if (multiPart instanceof MechanicalUpgradePartMachine upgradePartMachine) {
                 tier = Math.max(upgradePartMachine.tier, tier);

--- a/src/main/java/com/mo_guang/ctpp/common/machine/multiblock/KineticTurbineMachine.java
+++ b/src/main/java/com/mo_guang/ctpp/common/machine/multiblock/KineticTurbineMachine.java
@@ -78,14 +78,16 @@ public class KineticTurbineMachine extends KineticOutputMachine implements ITier
 
     public static @Nullable Component recipeModifier(MetaMachine machine, RecipeHandlerGroup group, GTRecipe recipe) {
         if (machine instanceof KineticTurbineMachine kmachine) {
-            int parallelResult = ParallelLogic.getParallelAmountFast(group, recipe,
-                    (int) pow(4, kmachine.tier - 3) * 5);
+            int parallelLimit = Math.max(1, (int) (pow(4, kmachine.tier - 3) * 5));
+            int parallelResult = ParallelLogic.getParallelAmountFast(group, recipe, parallelLimit);
             var rotorHolder = kmachine.getRotorHolder();
             if (rotorHolder == null || !rotorHolder.hasRotor()) {
                 return Component.translatable("gtceu.recipe_modifier.missing_valid_turbine_rotor");
             }
-            recipe.multiplyAllContents(parallelResult);
-            recipe.parallels *= parallelResult;
+            if (parallelResult > 1) {
+                recipe.multiplyAllContents(parallelResult);
+                recipe.parallels *= parallelResult;
+            }
             double holderEfficiency = rotorHolder.getTotalEfficiency() / 100.0;
             if (holderEfficiency <= 0) return Component.translatable("gtceu.recipe_modifier.missing_valid_turbine_rotor");
             double boostRate = rotorHolder.getRotorSpeed() < rotorHolder.getMaxRotorHolderSpeed() ?

--- a/src/main/java/com/mo_guang/ctpp/common/machine/multiblock/part/MechanicalUpgradePartMachine.java
+++ b/src/main/java/com/mo_guang/ctpp/common/machine/multiblock/part/MechanicalUpgradePartMachine.java
@@ -94,7 +94,7 @@ public class MechanicalUpgradePartMachine extends TieredIOPartMachine implements
     public void noticeController() {
         if (!getControllers().isEmpty() &&
                 getControllers().first() instanceof KineticMultiblockMachine kineticMultiblockMachine) {
-            kineticMultiblockMachine.tier = tier;
+            kineticMultiblockMachine.checkTier();
             kineticMultiblockMachine.onTierChanged();
         }
     }

--- a/src/main/java/com/mo_guang/ctpp/mixin/MultiblockStateMixin.java
+++ b/src/main/java/com/mo_guang/ctpp/mixin/MultiblockStateMixin.java
@@ -31,9 +31,9 @@ public class MultiblockStateMixin {
                                     IMultiController controller) {
         if (controller.isFormed() && controller instanceof KineticMultiblockMachine kineticMultiblockMachine) {
             if (!serverLevel.getBlockState(pos).getBlock().equals(Blocks.AIR)) {
-                var blazeBlocksPos = kineticMultiblockMachine.blazeBlocks.longStream().mapToObj(BlockPos::of).toList();
-                var rotateBlockPos = kineticMultiblockMachine.rotateBlocks.longStream().mapToObj(BlockPos::of).toList();
-                if (blazeBlocksPos.contains(pos) || rotateBlockPos.contains(pos)) {
+                long posLong = pos.asLong();
+                if ((kineticMultiblockMachine.blazeBlocks != null && kineticMultiblockMachine.blazeBlocks.contains(posLong)) ||
+                        (kineticMultiblockMachine.rotateBlocks != null && kineticMultiblockMachine.rotateBlocks.contains(posLong))) {
                     ci.cancel();
                 }
             }


### PR DESCRIPTION
This pull request addresses several critical bugs and runtime exceptions across machine logic, UI interaction, entity transformations, and mixin state handlers, while optimizing hot-path block state update checks.

### Proposed Changes:

**Bug Fixes:**
* **`CTPPMultiblockBuilder`:** Fixed self-invocation in `recoveryItems` by delegating to `super.recoveryItems(items)`, preventing infinite recursion and `StackOverflowError`.
* **`CTPPToolboxRadialScreen`:** Added null guard when querying `currentSource().source()` during deposit actions to prevent `NullPointerException` when no source is loaded.
* **`AcidWashingProcessingType` & `BreathingFanProcessingType`:** Added null checks following `EntityType.create()` invocations before attempting NBT deserialization.
* **`KineticMultiblockMachine` & `MechanicalUpgradePartMachine`:** Reset `tier = 0` prior to part iteration in `checkTier()` so mechanical tier downgrades and item extractions are accurately reflected.
* **`KineticTurbineMachine`:** Clamped parallel calculation to a minimum of 1 and guarded recipe content multiplication to prevent zeroing out recipe inputs and outputs on tiers < 3.

**Performance:**
* **`MultiblockStateMixin`:** Replaced stream construction and per-element object allocations with direct O(1) `LongSet.contains(long)` checks, eliminating garbage collection pressure and guarding against uninitialized set references.